### PR TITLE
Actualización 1.0 - Alpha

### DIFF
--- a/AnotaSuenos/ArchivosDesuso/paginationtest.php
+++ b/AnotaSuenos/ArchivosDesuso/paginationtest.php
@@ -1,0 +1,401 @@
+<?php
+require "../config.php";
+session_start();
+// find out how many rows are in the table 
+$sql = "SELECT COUNT(*) FROM Sueno";
+$result = mysqli_query($link, $sql);
+$r = mysqli_fetch_row($result);
+$numrows = $r[0];
+
+// number of rows to show per page
+$rowsperpage = 10;
+// find out total pages
+$totalpages = ceil($numrows / $rowsperpage);
+
+// get the current page or set a default
+if (isset($_GET['currentpage']) && is_numeric($_GET['currentpage'])) {
+    // cast var as int
+    $currentpage = (int) $_GET['currentpage'];
+} else {
+    // default page num
+    $currentpage = 1;
+} // end if
+
+// if current page is greater than total pages...
+if ($currentpage > $totalpages) {
+    // set current page to last page
+    $currentpage = $totalpages;
+} // end if
+// if current page is less than first page...
+if ($currentpage < 1) {
+    // set current page to first page
+    $currentpage = 1;
+} // end if
+
+// the offset of the list, based on current page 
+$offset = ($currentpage - 1) * $rowsperpage;
+
+// get the info from the db 
+$sql = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE sue_pri = 0 AND sue_m18 = 0 ORDER BY fec_sue DESC LIMIT $offset, $rowsperpage";
+$result = mysqli_query($link, $sql);
+
+// while there are rows to be fetched...
+while ($list = mysqli_fetch_assoc($result)) {
+    // echo data
+    echo "<div class='border border-info rounded p-3' style='width: 100%; background-color: white;'>";
+    $cantidadCarac = strlen($list["sueno"]);
+    $nombreUsuario = nombreUsuSueno($list["cod_usu"], $link);
+    $alto = heightTXA($cantidadCarac);
+    $cantComentarios = cantidadComentarios($list["id_sue"], $link);
+    $cantLikes = cantidadLikes($list["id_sue"], $link);
+    echo "<label>";
+    echo "Por: ";
+    echo "<a href='../CRUDs/perfilPublico.php?cod_usu=" . $list["cod_usu"] . "'>";
+    echo $nombreUsuario;
+    echo "</a>";
+    echo "</label>";
+    echo "<textarea class='form-control' id='textAreaSue" . $list["id_sue"] . "' style='resize:none;" . $alto . "border:none;maxlength:500;background-color:white;text-color:black;' disabled='true'>";
+    echo $list["sueno"];
+    echo "</textarea> <br>";
+    echo "<span>";
+    if ($list["sue_pri"] == 0) {
+        echo "Sueño público";
+    } else {
+        echo "Sueño privado";
+    }
+    echo "&nbsp;&nbsp;";
+    echo "</span>";
+    if ($list["sue_m18"] == 1) {
+        echo "<span> +18 </span> &nbsp;&nbsp;";
+    }
+    echo "<span>";
+    if (checkPropiedad($list["cod_usu"]) == 1) {
+        echo "<button id='" . $list["id_sue"] . "' class='modificar btn btn-warning'>Modificar</button>";
+        echo "&nbsp;";
+    }
+    echo "</span>";
+    echo "<span>";
+    if (checkLike($list["id_sue"], $_SESSION["id"], $link) == 0) {
+        echo "<button id='" . $list['id_sue'] . "' class='like btn btn-info'>Me gusta</button>";
+    } else {
+        echo "<button id='" . $list['id_sue'] . "' class='dislike btn btn-danger'>Ya no me gusta</button>";
+    }
+    echo "&nbsp;&nbsp;";
+    echo "Me gusta: ";
+    echo "<input type='text' disabled='true' id='cantLikes" . $list["id_sue"] . "' class='cantLikes' value='" . $cantLikes . "' style='border: none; width: 35px;' >";
+    echo "&nbsp;&nbsp;";
+    echo "</span>";
+    echo "<a  class='btn btn-info another-element' target='_TOP' href='../CRUDs/verComentarios.php?id_sue=" . $list["id_sue"] . "  '>Comentarios (" . $cantComentarios . ")</a>";
+    echo "</div> </br>";
+} // end while
+
+/******  build the pagination links ******/
+// range of num links to show
+$range = 3;
+
+// if not on page 1, don't show back links
+if ($currentpage > 1) {
+    // show << link to go back to page 1
+    
+    echo " <a href='{$_SERVER['PHP_SELF']}?currentpage=1'><<</a> ";
+    // get previous page num
+    $prevpage = $currentpage - 1;
+    // show < link to go back to 1 page
+    echo " <a href='{$_SERVER['PHP_SELF']}?currentpage=$prevpage'><</a> ";
+} // end if 
+
+// loop to show links to range of pages around current page
+for ($x = ($currentpage - $range); $x < (($currentpage + $range) + 1); $x++) {
+    // if it's a valid page number...
+    if (($x > 0) && ($x <= $totalpages)) {
+        // if we're on current page...
+        if ($x == $currentpage) {
+            // 'highlight' it but don't make a link
+            echo " [<b>$x</b>] ";
+            // if not current page...
+        } else {
+            // make it a link
+            echo " <a href='{$_SERVER['PHP_SELF']}?currentpage=$x'>$x</a> ";
+        } // end else
+    } // end if 
+} // end for
+
+// if not on last page, show forward and last page links        
+if ($currentpage != $totalpages) {
+    // get next page
+    $nextpage = $currentpage + 1;
+    // echo forward link for next page 
+    echo " <a href='{$_SERVER['PHP_SELF']}?currentpage=$nextpage'>></a> ";
+    // echo forward link for lastpage
+    echo " <a href='{$_SERVER['PHP_SELF']}?currentpage=$totalpages'>>></a> ";
+} // end if
+/****** end build pagination links ******/
+
+
+//funcion heightTXA 
+//Input: cántidad de caracteres de un sueño
+//Output: Altura de textarea que ocupará el sueño.
+function heightTXA($cantidadCarac)
+{ 
+    $altoTXA = "height:100px;";
+    if ($cantidadCarac <= 100) {
+        $altoTXA = "height:84px;";
+    }
+    if ($cantidadCarac > 100 && $cantidadCarac <= 200) {
+        $altoTXA = "height:135px;";
+    }
+    if ($cantidadCarac > 200 && $cantidadCarac <= 300) {
+        $altoTXA = "height:190px;";
+    }
+    if ($cantidadCarac > 300 && $cantidadCarac <= 400) {
+        $altoTXA = "height:160px;";
+    }
+    if ($cantidadCarac > 400) {
+        $altoTXA = "height:300px;";
+    }
+    return $altoTXA;
+}
+
+//Función nombreUsuSueno
+//Input: Código de usuario y Link de conexión.
+//Output: Nombre de usuario correspondiente al sueño.
+function nombreUsuSueno($codusu, $link)
+{
+    $sql = "SELECT nom_usu FROM Login WHERE cod_usu = ?";
+    if ($stmt = mysqli_prepare($link, $sql)) {
+        mysqli_stmt_bind_param($stmt, "i", $param_codusu);
+        $param_codusu = $codusu;
+        if (mysqli_stmt_execute($stmt)) {
+            mysqli_stmt_store_result($stmt);
+            if (mysqli_stmt_num_rows($stmt) == 1) {
+                mysqli_stmt_bind_result($stmt, $nombreUsuario);
+                if (mysqli_stmt_fetch($stmt)) {
+                    return $nombreUsuario;
+                }
+            } else {
+                return "No se encontró el usuario";
+            }
+        }
+    }
+    return "Usuario no encontrado";
+}
+
+//Función cantidadComentarios
+//Input: Código de sueño y Link de conexión.
+//Output: Cantidad de comentarios correspondientes al sueño.
+function cantidadComentarios($id_sue, $link)
+{
+    $result = mysqli_query($link, "SELECT count(*) as total FROM Comentario WHERE id_sue = " . $id_sue . " ");
+    $data = mysqli_fetch_assoc($result);
+    return $data["total"];
+}
+
+//Función cantidadLikes
+//Input: Código de sueño y Link de conexión.
+//Output: Cantidad de likes correspondientes al sueño.
+function cantidadLikes($id_sue, $link)
+{
+    $result = mysqli_query($link, "SELECT count(*) as total FROM LikeDislike WHERE id_sue = " . $id_sue . " ");
+    $data = mysqli_fetch_assoc($result);
+    return $data["total"];
+}
+
+//Función checkLike
+//Input: Código de sueño, Código de usuario y Link de conexión
+//Output: Cantidad de likes que el usuario en sesión ha dado al sueño.
+//Nota: No puede ser mayor que 1 ni menor que 0.
+function checkLike($id_sue, $id_usu, $link)
+{
+    $result = mysqli_query($link, "SELECT count(*) as total FROM LikeDislike WHERE id_sue = " . $id_sue . " AND id_usu =" . $id_usu . " ");
+    $data = mysqli_fetch_assoc($result);
+    return $data["total"];
+}
+
+//Función checkPropiedad
+//Input: Directo: Código de usuario del sueño - Indirecto: Código de usuario en sesión.
+//Output: 1: El usuario es propietario del sueño - 0: El usuario NO es propietario del sueño.
+function checkPropiedad($id_usu)
+{
+    $id_usu_sue = $id_usu;
+    $id_usu_ses = $_SESSION["id"];
+    if ($id_usu_sue == $id_usu_ses) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+    <link rel="stylesheet" href="estilo.css">
+</head>
+
+<body style="background-color: transparent;">
+
+</body>
+<script>
+
+$(document).on("click",".like", function(){
+    console.log("INICIANDO PROCESO: BOTON LIKE");
+    var id_sue = $(this).attr("id");
+    var funcion = "insertLike";
+    var button = $(this);
+    //alert("AGGA"+id_sue);
+    var paquete = "funcion="+funcion+"&id_sue="+id_sue;
+    console.log("PAQUETE: "+paquete);
+    //alert(paquete);
+    $.ajax({
+        type: "POST",
+        url: "http://anotasuenos:8080/CRUDs/handlerAuxSuenos.php",
+        data: paquete,
+    }).done(function(respuesta){
+        button.text("Ya no me gusta");
+        console.log("TEXTO CAMBIADO: Ya no me Gusta");
+        button.removeClass("btn-info");
+        button.removeClass("like");
+        console.log("CLASES REMOVIDAS");
+        button.addClass("btn-danger");
+        button.addClass("dislike");
+        console.log("CLASES AÑADIDAS");
+        console.log("Respuesta: "+respuesta);
+        document.getElementById("cantLikes"+id_sue).value = respuesta;
+        console.log("CANTIDAD DE ME GUSTA ACTUALIZADA");
+        event.stopPropagation();
+    }).fail(function(respuesta){
+        alert("Error de conexión. Probablemente.");
+    })
+});
+
+$(document).on("click",".dislike", function(){
+    console.log("INICIANDO PROCESO: BOTON DISLIKE");
+    var id_sue = $(this).attr("id");
+    var button = $(this);
+    var funcion = "deleteLike";
+    var paquete = "funcion="+funcion+"&id_sue="+id_sue;
+    console.log("PAQUETE: "+paquete);
+    $.ajax({
+        type: "POST",
+        url: "http://anotasuenos:8080/CRUDs/handlerAuxSuenos.php",
+        data: paquete,
+    }).done(function(respuesta){
+        button.text("Me gusta");
+        console.log("TEXTO CAMBIADO: Me Gusta");
+        button.removeClass("btn-danger");
+        button.removeClass("dislike");
+        console.log("CLASES REMOVIDAS");
+        button.addClass("btn-info");
+        button.addClass("like");
+        console.log("CLASES AÑADIDAS");
+        console.log("Respuesta: "+respuesta);
+        document.getElementById("cantLikes"+id_sue).value = respuesta;
+        console.log("CANTIDAD DE ME GUSTA ACTUALIZADA");
+        event.stopPropagation();
+    }).fail(function(respuesta){
+        alert("Error de conexión. Probablemente.");
+    })
+});
+
+$(document).on("click",".modificar",function(){
+    console.log("Botón modificar sueño - Iniciado");
+    var id_sue = $(this).attr("id");
+    console.log("ID BUTTON Y SUEÑO = "+id_sue);
+    var button = $(this);
+    button.text("Guardar");
+    console.log("Quitar clases actuales referentes al funcionamiento del botón");
+    button.removeClass("modificar");
+    button.removeClass("btn-warning");
+    console.log("Añadir clases necesarias para el nuevo funcionamiento del botón");
+    button.addClass("btn-info");
+    button.addClass("guardarCambios");
+    //Conseguir el texto del sueño para luego utilizarlo de alguna forma.
+    var textArea = document.getElementById("textAreaSue"+id_sue).innerHTML;
+    console.log(textArea);
+    //Tomar control sobre el textarea por medio de su id.
+    var controlTXA = document.getElementById("textAreaSue"+id_sue);
+    controlTXA.style="border-stiyle:solid;border-color:black;resize:none;";
+    controlTXA.removeAttribute("disabled");
+    event.stopPropagation();
+});
+
+$(document).on("click",".guardarCambios",function(){
+    console.log("Botón guardar cambios sueño - Iniciando");
+    var id_sue = $(this).attr("id");
+    console.log("ID BOTÓN Y SUEÑO = "+id_sue);
+    //Tomar control del botón y del textarea
+    var button = $(this);
+    var controlTXA = document.getElementById("textAreaSue"+id_sue);
+    //Conseguir valor nuevo del textarea
+    var textArea = controlTXA.value;
+    var alto = heightTXA(textArea.length);
+    if(textArea == null || textArea == ''){
+        alert("El sueño no puede estar vacío");
+        return null;
+    }else if(textArea.length > 500){
+        alert("El sueño no puede pasar de 500 caracteres. Tienes "+textArea.length);
+        return null;
+    }
+    //empaquetar la información
+    var paquete = "funcion=modificarSueno&id_sue="+id_sue+"&nuevoSue="+textArea;
+    console.log(paquete);
+    $.ajax({
+        type: "POST",
+        url: "http://anotasuenos:8080/CRUDs/handlerAuxSuenos.php",
+        data: paquete,
+    }).done(function(respuesta){
+        button.text("Modificar");
+        console.log("Quitar clases actuales referentes al funcionamiento del botón");
+        button.removeClass("btn-info");
+        button.removeClass("guardarCambios");
+        console.log("Añadir clases necesarias para el nuevo funcionamiento del botón");
+        button.addClass("modificar");
+        button.addClass("btn-warning");
+        document.getElementById("textAreaSue"+id_sue).innerHTML = respuesta;
+        console.log("RESPUESTA: "+respuesta);
+        controlTXA.style="border:none;resize:none;background-color:white;"+alto+"";
+        controlTXA.setAttribute("disabled","true");
+        console.log("Botón guardar cambios sueño - Finalizado");
+        alert("Sueño modificado.");
+        event.stopPropagation();
+    }).fail(function(respuesta){
+        document.getElementById("textAreaSue"+id_sue).innerHTML = respuesta;
+    });
+});
+
+
+//Esta función existe en formato PHP, pero para aplicar el estilo al modificar un comentario
+//Es necesaria esta copia en javascript. Hacen lo mismo, pero usarla en formato php significaría
+//Usar ajax con redirección a esta misma página, es posible, y de hecho podría implementarse una función
+//en handlerAuxSuenos.php que se encargue de esto siempre que sea necesario, de momento, esta solución
+//está funcionando y correctamente.
+function heightTXA(cantidadCarac){
+        var altoTXA = "height:100px;";
+        if(cantidadCarac <= 100){
+            altoTXA = "height:84px;";
+        }
+        if(cantidadCarac > 100 && cantidadCarac <= 200){
+            altoTXA = "height:135px;";
+        }
+        if(cantidadCarac > 200 && cantidadCarac <=300){
+            altoTXA = "height:190px;";
+        }
+        if(cantidadCarac > 300 && cantidadCarac <= 400){
+            altoTXA = "height:160px;";
+        }
+        if(cantidadCarac > 400){
+            altoTXA = "height:300px;";
+        }
+        return altoTXA;
+        
+}
+</script>
+</html>

--- a/AnotaSuenos/CRUDs/handlerAuxUsuario.php
+++ b/AnotaSuenos/CRUDs/handlerAuxUsuario.php
@@ -62,22 +62,19 @@ function cantSueUsuario($id_usu,$link){
 function updateDescrUsuario($link){
     $nueva_des = $_POST["nuevaDes"];
     $cod_usu = $_SESSION["id"];
-
     $sql = "UPDATE Login SET des_usu=? WHERE cod_usu=? ";
-
     if($stmt = mysqli_prepare($link,$sql)){
         mysqli_stmt_bind_param($stmt,"si",$des_param,$cod_usu_param);
         $des_param = $nueva_des; 
         $cod_usu_param = $cod_usu;
         if(mysqli_stmt_execute($stmt)){
             //BUG: No se muestra este mensaje cuando la nueva descripción viene vacía.
-            if($nueva_des == null || $nueva_des = ''){
-                echo "Este usuario no ha escrito ninguna descripción.";
+            if($nueva_des == null || $nueva_des == ''){
+                $nueva_des = "Este usuario no ha escrito ninguna descripción.";
+                echo $nueva_des;
             }else{
                 echo $nueva_des;
             }
-        }else{
-            echo "No se pudo actualizar la descripción. Help.";
         }
     }else{
         echo "Falla de conexión.";

--- a/AnotaSuenos/CRUDs/mostrarSuenos.php
+++ b/AnotaSuenos/CRUDs/mostrarSuenos.php
@@ -6,9 +6,9 @@ $function = $_GET["function"];
 
 switch ($function) {
     case "mostrarSuenosNPVNM18":
-        $offsetQuery = $_GET["offset"];
-        $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE sue_pri = 0 AND sue_m18 = 0 ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
-        mostrarSuenosGeneric($query, $link);
+        // $offsetQuery = $_GET["offset"];
+        // $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE sue_pri = 0 AND sue_m18 = 0 ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
+        // mostrarSuenosGeneric($query, $link);
         break;
     case "mostrarSueCustomQuery":
         prepararQuery($link);
@@ -50,16 +50,34 @@ function prepararQuery($link)
             //Esta opción es exclusiva para el usuario en sesión que visite su perfil y solo aparecerá si el chequeo de propiedad da 1, es decir, positivo.
             //Deben aparecer todos los sueños del usuario.
             $cod_usu = $_GET["cod_usu"];
-            $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE cod_usu = " . $cod_usu . " ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
-            mostrarSuenosGeneric($query, $link);
+            if($cod_usu == $_SESSION["id"]){
+                $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE cod_usu = " . $cod_usu . " ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
+                mostrarSuenosGeneric($query, $link);
+            }else{
+                echo "<script> alert('Si de verdad quieres ver lo que este usuario no quiere que veas, pídeselo, a ver que dice. Volviendo a home.'); </script>";
+                //Esta función fue tomada desde StackOverflow. Gracias Dan Heberden.
+                echo  "<script>";
+                echo "parent.changeURL('../home.php' );";
+                echo "</script>";
+                //Fin.
+            }
             break;
         case "soloPVUser":
             //Los sueños que sean privados, sin importar si son +18 o no del usuario.
             //Opción exclusiva para el usuario en sesión que visita su propio perfil.
             //Deben aparecer todos los sueños privados, sin importar si son +18 o no.
             $cod_usu = $_GET["cod_usu"];
-            $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE sue_pri = 1 AND cod_usu = " . $cod_usu . " ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
-            mostrarSuenosGeneric($query, $link);
+            if($cod_usu == $_SESSION["id"]){
+                $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE sue_pri = 1 AND cod_usu = " . $cod_usu . " ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
+                mostrarSuenosGeneric($query, $link);
+            }else{
+                echo "<script> alert('¿Inspeccionar elemento? Casi resulta. Volviendo a home.'); </script>";
+                //Esta función fue tomada desde StackOverflow. Gracias Dan Heberden.
+                echo  "<script>";
+                echo "parent.changeURL('../home.php' );";
+                echo "</script>";
+                //Fin.
+            }
             break;
         case "soloM18User":
             //Los sueños que sean públicos y +18.
@@ -69,8 +87,14 @@ function prepararQuery($link)
             $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,cod_usu FROM Sueno WHERE sue_pri = 0 AND sue_m18 = 1 AND cod_usu = " . $cod_usu . " ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
             mostrarSuenosGeneric($query, $link);
             break;
+        case "soloSeguidosNoM18":
+            //Los sueños correspondientes a los usuarios seguidos por el usuario en sesión
+            //Opción disponible para todos los usuarios.
+            //Esta opción NO funciona hasta ahora.
+            $query = "SELECT id_sue,sueno,sue_pri,sue_m18,fec_sue,Sueno.cod_usu FROM Sueno,Seguidores,Login WHERE Sueno.cod_usu = Seguidores.id_usu_sdo AND Seguidores.id_usu_sdr = ".$_SESSION["id"]." AND Sueno.sue_pri = 0 AND Sueno.sue_m18 = 0 ORDER BY fec_sue DESC LIMIT 10 OFFSET " . $offsetQuery . " ";
+            mostrarSuenosGeneric($query, $link);
+            break;
     }
-    return $query;
 }
 
 //Función genérica para mostrar sueños:
@@ -103,8 +127,7 @@ function mostrarSuenosGeneric($query, $link)
             } else {
                 echo "Sueño privado";
             }
-            echo "&nbsp;&nbsp;";
-            echo "</span>";
+            echo "&nbsp;&nbsp;</span>";
             if ($row["sue_m18"] == 1) {
                 echo "<span> +18 </span> &nbsp;&nbsp;";
             }
@@ -119,11 +142,9 @@ function mostrarSuenosGeneric($query, $link)
             } else {
                 echo "<button id='" . $row['id_sue'] . "' class='dislike btn btn-danger'>Ya no me gusta</button>";
             }
-            echo "&nbsp;&nbsp;";
-            echo "Me gusta: ";
+            echo "&nbsp;&nbsp;Me gusta: ";
             echo "<input type='text' disabled='true' id='cantLikes" . $row["id_sue"] . "' class='cantLikes' value='" . $cantLikes . "' style='border: none; width: 35px;' >";
-            echo "&nbsp;&nbsp;";
-            echo "</span>";
+            echo "&nbsp;&nbsp;</span>";
             echo "<a  class='btn btn-info another-element' href='../CRUDs/verComentarios.php?id_sue=" . $row["id_sue"] . " '>Comentarios (" . $cantComentarios . ")</a>";
             echo "</div> </br>";
             array_push($response["suenos"], $temp);
@@ -410,6 +431,13 @@ function checkPropiedad($id_usu)
         return altoTXA;
 
     }
+
+
+    //Función tomada desde Stack Overflow - Usuario Dan Heberden
+    function changeURL( url ) {
+        document.location = url;
+    }
+    //Fin.
 </script>
 
 </html>

--- a/AnotaSuenos/CRUDs/perfilPublico.php
+++ b/AnotaSuenos/CRUDs/perfilPublico.php
@@ -162,6 +162,7 @@
     <?php
         echo "<div hidden='true'>";
         echo "<input type='hidden' id='cod_usuHid' value='".$_GET["cod_usu"]."'>";
+        echo "<input type='hidden' id='filtroActual' value='default'";
         echo " </div>";
     ?>
 </body>
@@ -290,6 +291,7 @@ function listarRegistrosUsuarioPerf(){
     var offSetDspl = "0";
     document.getElementById("offsetDisplay").innerHTML = offSetDspl;
     document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+    document.getElementById("filtroActual").value = "noPVnoM18User";
     $.ajax({
         type: "GET",
         url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
@@ -308,6 +310,7 @@ $(document).on("click","#mostrarPriv",function(){
     var offSetDspl = "0";
     document.getElementById("offsetDisplay").innerHTML = offSetDspl;
     document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+    document.getElementById("filtroActual").value = "noPVnoM18User";
     $("#mostrarSuenosPublic").html("Cargando sueños...");
     $.ajax({
         type: "GET",
@@ -327,6 +330,7 @@ $(document).on("click","#mostrarPublic",function(){
     var offSetDspl = "0";
     document.getElementById("offsetDisplay").innerHTML = offSetDspl;
     document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+    document.getElementById("filtroActual").value = "noPVnoM18User";
     $.ajax({
         type: "GET",
         url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
@@ -345,6 +349,7 @@ $(document).on("click","#mostrarM18",function(){
     var offSetDspl = "0";
     document.getElementById("offsetDisplay").innerHTML = offSetDspl;
     document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+    document.getElementById("filtroActual").value = "soloM18User";
     $.ajax({
         type: "GET",
         url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
@@ -363,6 +368,7 @@ $(document).on("click","#mostrarM18Public",function(){
     var offSetDspl = "0";
     document.getElementById("offsetDisplay").innerHTML = offSetDspl;
     document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+    document.getElementById("filtroActual").value = "noPVsiM18User";
     $.ajax({
         type: "GET",
         url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
@@ -381,6 +387,7 @@ $(document).on("click","#mostrarAllM18PubPri",function(){
     var offSetDspl = "0";
     document.getElementById("offsetDisplay").innerHTML = offSetDspl;
     document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+    document.getElementById("filtroActual").value = "todosUser";
     $.ajax({
         type: "GET",
         url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
@@ -399,6 +406,7 @@ $(document).on("click","#queryUserPerf",function(){
     var offSetDspl = "0";
     document.getElementById("offsetDisplay").innerHTML = offSetDspl;
     document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+    document.getElementById("filtroActual").value = "noPVnoM18User";
     $.ajax({
         type: "GET",
         url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
@@ -494,7 +502,8 @@ $('#siguientes10').click(function(){
     //Estos dos deben ser iguales siempre 0 - 0 -> 10 - 10
     //En este caso, se hace automáticamente.
     var cod_usu = document.getElementById("cod_usuHid").value;
-    var offset = "function=mostrarSueCustomQuery&opcion=noPVnoM18User&cod_usu="+cod_usu+"&offset="+newOffset;
+    var opcion = document.getElementById("filtroActual").value;
+    var offset = "function=mostrarSueCustomQuery&opcion="+opcion+"&cod_usu="+cod_usu+"&offset="+newOffset;
     var offsetDspl = newOffset;
     var offsetLimDspl = parseInt(offsetDspl) + parseInt(10);
     console.log("Siguientes 10: Variables definidas");
@@ -546,7 +555,8 @@ $('#anteriores10').click(function(){
 
     //Definir variables para el offset.
     var cod_usu = document.getElementById("cod_usuHid").value;
-    var offset = "function=mostrarSueCustomQuery&opcion=noPVnoM18User&cod_usu="+cod_usu+"&offset="+parseInt(newOffset);
+    var opcion = document.getElementById("filtroActual").value;
+    var offset = "function=mostrarSueCustomQuery&opcion="+opcion+"&cod_usu="+cod_usu+"&offset="+parseInt(newOffset);
     var offsetDspl = newOffset;
     var offsetLim = parseInt(offsetDspl) + parseInt(10);
     console.log("Anteriores 10: Variables definidas");

--- a/AnotaSuenos/Creditos.php
+++ b/AnotaSuenos/Creditos.php
@@ -4,5 +4,5 @@ echo "<a href='https://icons8.com/icon/2908/help'>Help icon by Icons8</a>";
 echo "PHP Pagination script : https://stackoverflow.com/questions/3705318/simple-php-pagination-script";
 echo "No podría haber creado un login seguro sin este tutorial.";
 echo "https://www.tutorialrepublic.com/php-tutorial/php-mysql-login-system.php";
-
+echo "Dan Heberden - Cambiar de url sin usar header, que se buguea : https://stackoverflow.com/questions/2985353/php-header-location-inside-iframe-to-load-in-top-location";
 ?>

--- a/AnotaSuenos/TODO.txt
+++ b/AnotaSuenos/TODO.txt
@@ -104,4 +104,22 @@ Versión 0.9
 -Se cambiaron los "ifs" del archivo mostrarComentarios.php por un switch.
 -Las funciones del archivo mostrarComentarios ahora utilizan la configuración de config.php en lugar de ser declaradas dentro de las funciones.
 -El botón para seguir/dejar de seguir usuarios ya es completamente funcional.
+
+Versión 1.0
+-Se añadió un chequeo de propiedad al intentar ver sueños. El sitio verificará primero si el sueño es privado, si lo es, verificará la propiedad.
+ si el usuario que intenta acceder al sueño NO es propietario, el sitio dará aviso y enviará al usuario a la página home. Si es el propietario mostrará
+ el sueño normalmente. Finalmente, si el sueño no es privado, no se realizará la verificación de propiedad y el sueño se mostrará sin problema.
+-Se actualizó la función verSueno para reflejar los cambios hechos a la función mostrarSuenosGeneric().
+-Ahora el hacer click en el nombre de usuario llevará al usuario a su propio perfil.
+-Se añadió la función para ver sueños solo de usuarios seguidos. Sin embargo, no es compatible con la paginación. Todavía.
+-Se añadió el botón "Ver Seguidos" para listar los sueños solo de usuarios seguidos para realizar pruebas.
+-Se añadió una variable para controlar los filtros que posibilitará usar la paginación dentro de los perfiles de usuario y próximamente dentro de la página home.
+-La variable para controlar los filtros mencionada en el punto anterior parece funcionar correctamente, se deberían realizar más pruebas, incluidas pruebas con hackeo.
+-Se identificó un fallo de seguridad en el que los usuarios podrán ver sueños privados sin ser propietarios del mismo.
+-Aparentemente, se solucionó este fallo de seguridad, sin embargo se necesitan hacer más pruebas para poder asegurarlo completamente.
+-Se cambió la opción en ajax para ver los sueños. Ahora forma parte del listado de consultas preparadas.
+-Se implementó el control de filtros en la página home. Ahora implementar nuevos filtros será mucho más sencillo.
+
+Versión 1.1
+
 -TODO: Crear las opciones para eliminar sueños, modificar comentarios y eliminar comentarios.

--- a/AnotaSuenos/home.php
+++ b/AnotaSuenos/home.php
@@ -61,7 +61,7 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
             <div class="col-md-4">
                 <div id="contenedorMiniPerfil" class="center border border-info rounded p-3" style="background-color:white;">
                     <span><img src="https://img.icons8.com/ios-filled/50/000000/help.png" width="50px" height="50px" alt="FDP" /></span>
-                    <span id="nomUsuMiniPerfil"><?php echo $_SESSION["username"]; ?></span><br><br>
+                    <span id="nomUsuMiniPerfil">  <a href="../CRUDs/perfilPublico.php?cod_usu=<?php echo $_SESSION["id"];?>" > <?php echo $_SESSION["username"]; ?>  </a>    </span><br><br>
                     <p><a href="Registro\logout.php" class="btn btn-danger">Cerrar sesión</a></p>
                 </div> <br>
                 <div id="contenedorEstadisticas" class="center border border-info rounded p-3" style="background-color:white;">
@@ -77,11 +77,16 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
                     <p id="cantidadComent">Cargando...</p>
                     <p id="cantidadLikesComent">Cargando...</p>
                     <button id="actualizarEstadisticas" class="btn btn-info">Actualizar</button>
+                    <button id="verSeguidos" class="btn btn-info">Ver seguidos</button>
                 </div>
             </div>
         </div>
     </div>
-
+    <?php
+        echo "<div hidden='true'>";
+        echo "<input type='hidden' id='filtroActual' value='default '";
+        echo " </div>";
+    ?>
 </body>
 <!-- FIN BODY -->
 <script>
@@ -120,14 +125,15 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
 
         //Estos dos deben ser iguales siempre 0 - 0 -> 10 - 10
         //En este caso, se hace automáticamente.
-        var offset = "function=mostrarSuenosNPVNM18&offset=" + newOffset;
+        var opcion = document.getElementById("filtroActual").value;
+        var offset = "function=mostrarSueCustomQuery&opcion="+opcion+"&offset=" + newOffset;
         var offsetDspl = newOffset;
         var offsetLimDspl = parseInt(offsetDspl) + parseInt(10);
         console.log("Siguientes 10: Variables definidas");
 
         var limite = parseInt(document.getElementById("cantidadTotalSuenos").innerHTML);
         if (limite > newOffset && limite < offsetLimDspl) {
-            offset = "function=mostrarSuenosNPVNM18&offset=" + limite;
+            offset = "function=mostrarSueCustomQuery&opcion="+opcion+"&offset=" + limite;
         }
 
         //Mostrar nuevos valores en la página
@@ -171,7 +177,8 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
         }
 
         //Definir variables para el offset.
-        var offset = "function=mostrarSuenosNPVNM18&offset=" + parseInt(newOffset);
+        var opcion = document.getElementById("filtroActual").value;
+        var offset = "function=mostrarSueCustomQuery&opcion="+opcion+"&offset=" + parseInt(newOffset);
         var offsetDspl = newOffset;
         var offsetLim = parseInt(offsetDspl) + parseInt(10);
         console.log("Anteriores 10: Variables definidas");
@@ -197,6 +204,24 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
 
     $('#actualizarEstadisticas').click(function() {
         mostrarEstadisticas();
+    });
+
+    $('#verSeguidos').click(function(){
+        var paquete = "function=mostrarSueCustomQuery&offset=0&opcion=soloSeguidosNoM18";
+        var offSetDspl = "0";
+        document.getElementById("offsetDisplay").innerHTML = offSetDspl;
+        document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+        document.getElementById("filtroActual").value = "soloSeguidosNoM18";
+        $.ajax({
+            type: "GET",
+            url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
+            dataType: "html",
+            data: paquete,
+        }).done(function(res){
+            $("#mostrarSuenosPublic").html(res);
+        }).fail(function(){
+            $("#mostrarSuenosPublic").html("Algo falló.");
+        });
     });
 
     function cambiarSpans(offsetDspl, offsetLimDspl) {
@@ -246,14 +271,14 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
     }
 
     function listarRegistrosNPVNM18() {
-        var offset = "function=mostrarSuenosNPVNM18&offset=0";
+        var offset = "function=mostrarSueCustomQuery&opcion=noPVnoM18&offset=0";
         var offSetDspl = "0";
         document.getElementById("offsetDisplay").innerHTML = offSetDspl;
         document.getElementById("offsetLimDisplay").innerHTML = parseInt(offSetDspl) + parseInt(10);
+        document.getElementById("filtroActual").value = "noPVnoM18";
         $.ajax({
             type: "GET",
             url: "http://anotasuenos:8080/CRUDs/mostrarSuenos.php",
-            // url: "http://anotasuenos:8080/CRUDs/paginationtest.php",
             dataType: "html",
             data: offset,
         }).done(function(respuesta) {
@@ -433,5 +458,4 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
     }
     //Fin sección estadísticas
 </script>
-
 </html>


### PR DESCRIPTION
-Se añadió un chequeo de propiedad al intentar ver sueños. El sitio verificará primero si el sueño es privado, si lo es, verificará la propiedad.
 si el usuario que intenta acceder al sueño NO es propietario, el sitio dará aviso y enviará al usuario a la página home. Si es el propietario mostrará
 el sueño normalmente. Finalmente, si el sueño no es privado, no se realizará la verificación de propiedad y el sueño se mostrará sin problema.
-Se actualizó la función verSueno para reflejar los cambios hechos a la función mostrarSuenosGeneric().
-Ahora el hacer click en el nombre de usuario llevará al usuario a su propio perfil.
-Se añadió la función para ver sueños solo de usuarios seguidos. Sin embargo, no es compatible con la paginación. Todavía.
-Se añadió el botón "Ver Seguidos" para listar los sueños solo de usuarios seguidos para realizar pruebas.
-Se añadió una variable para controlar los filtros que posibilitará usar la paginación dentro de los perfiles de usuario y próximamente dentro de la página home.
-La variable para controlar los filtros mencionada en el punto anterior parece funcionar correctamente, se deberían realizar más pruebas, incluidas pruebas con hackeo.
-Se identificó un fallo de seguridad en el que los usuarios podrán ver sueños privados sin ser propietarios del mismo.
-Aparentemente, se solucionó este fallo de seguridad, sin embargo se necesitan hacer más pruebas para poder asegurarlo completamente.
-Se cambió la opción en ajax para ver los sueños. Ahora forma parte del listado de consultas preparadas.
-Se implementó el control de filtros en la página home. Ahora implementar nuevos filtros será mucho más sencillo.